### PR TITLE
[Lixing] move fundamental chapter tranlsation to correct file

### DIFF
--- a/manuscript/04-graphql-fundamentals/index-cn.md
+++ b/manuscript/04-graphql-fundamentals/index-cn.md
@@ -408,13 +408,21 @@ GraphQL中的查询为你提供了从 GraphQL API 读取数据时的全部功能
   * 具名操作
   * 指令
 
-## GraphQL Operation: Mutation
+> ## GraphQL Operation: Mutation
 
-This section introduces the GraphQL mutation. It complements the GraphQL query because it is used for writing data instead of reading it. The mutation shares the same principles as the query: it has fields and objects, arguments and variables, fragments and operation names, as well as directives and nested objects for the returned result. With mutations you can specify data as fields and objects that should be returned after it 'mutates' into something acceptable. Before you start making your first mutation, be aware that you are using live GitHub data, so if you follow a person on GitHub using your experimental mutation, you will follow this person for real. Fortunately this sort of behavior is encouraged on GitHub.
+## GraphQL 基础：变更
 
-In this section, you will star a repository on GitHub, the same one you used a query to request before, using a mutation [from GitHub's API](https://developer.github.com/v4/mutation/addstar). You can find the `addStar` mutation in the "Docs" sidebar. The repository is a project for teaching developers about the fundamentals of React, so starring it should prove useful.
+> This section introduces the GraphQL mutation. It complements the GraphQL query because it is used for writing data instead of reading it. The mutation shares the same principles as the query: it has fields and objects, arguments and variables, fragments and operation names, as well as directives and nested objects for the returned result. With mutations you can specify data as fields and objects that should be returned after it 'mutates' into something acceptable. Before you start making your first mutation, be aware that you are using live GitHub data, so if you follow a person on GitHub using your experimental mutation, you will follow this person for real. Fortunately this sort of behavior is encouraged on GitHub.
 
-You can visit [the repository](https://github.com/the-road-to-learn-react/the-road-to-learn-react) to see if you've given a star to the repository already. We want an unstarred repository so we can star it using a mutation. Before you can star a repository, you need to know its identifier, which can be retrieved by a query:
+这部分将会介绍 GraphQL 变更操作。它作为 GraphQL 查询的补充，用于改写数据而不是读取。变更操作和查询操作拥有着同样的规则：拥有字段和对象、参数和变量、片段和操作名称、指令和返回结果中的嵌套对象。通过变更操作你可以指定在"更新"发生后所期望的返回数据的字段和对象。在你开始你的第一次变更操作之前，请注意你在使用真实的 GitHub 数据，也就是说如果你在尝试变更操作的时候关注了 GitHub 上的一个人，你就真的关注了这个人。幸运的是这种行为在 GitHub 上是受到鼓励的。
+
+> In this section, you will star a repository on GitHub, the same one you used a query to request before, using a mutation [from GitHub's API](https://developer.github.com/v4/mutation/addstar). You can find the `addStar` mutation in the "Docs" sidebar. The repository is a project for teaching developers about the fundamentals of React, so starring it should prove useful.
+
+接下来你将会 star 一个 GitHub 上的代码库，而和你之前使用一个查询来请求一样，你将使用[来自 GitHub API ](https://developer.github.com/v4/mutation/addstar)的一个变更请求。你可以在 "Docs" 侧边栏中找到 `addStar` 这种变更操作。这是一个存放为开发者讲解 React 基础课程的代码库，所以 star 这个代码库能够证明它有用。
+
+> You can visit [the repository](https://github.com/the-road-to-learn-react/the-road-to-learn-react) to see if you've given a star to the repository already. We want an unstarred repository so we can star it using a mutation. Before you can star a repository, you need to know its identifier, which can be retrieved by a query:
+
+你可以访问[这个代码库](https://github.com/the-road-to-learn-react/the-road-to-learn-react)来查看你是否已经成功 star 。我们想要一个尚未 star 过的代码库，这样我们可以通过一个变更操作来 star 它。在你 star 一个代码库前，你需要知道它的唯一标识。这个唯一标识你可以通过下面的查询获取：
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -432,14 +440,18 @@ query {
 }
 ~~~~~~~~
 
-In the results for the query in GraphiQL, you should see the identifier for the repository:
+> In the results for the query in GraphiQL, you should see the identifier for the repository:
+
+在 GraphiQL 的该查询结果中，你应该能看到代码库的唯一标识：
 
 {title="Code Playground",lang="json"}
 ~~~~~~~~
 MDEwOlJlcG9zaXRvcnk2MzM1MjkwNw==
 ~~~~~~~~
 
-Before using the identifier as a variable, you can structure your mutation in GraphiQL the following way:
+>  Before using the identifier as a variable, you can structure your mutation in GraphiQL the following way:
+
+在使用唯一标示作为变量之前，你可以在 GraphiQL 中使用以下结构的变更操作：
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -453,7 +465,9 @@ mutation AddStar($repositoryId: ID!) {
 }
 ~~~~~~~~
 
-The mutation's name is given by GitHub's API: `addStar`. You are required to pass it the `starrableId` as `input` to identify the repository; otherwise, the GitHub server won't know which repository to star with the mutation. In addition, the mutation is a named mutation: `AddStar`. It's up to you to give it any name. Last but not least, you can define the return values of the mutation by using objects and fields again. It's identical to a query. Finally, the variables tab provides the variable for the mutation you retrieved with the last query:
+> The mutation's name is given by GitHub's API: `addStar`. You are required to pass it the `starrableId` as `input` to identify the repository; otherwise, the GitHub server won't know which repository to star with the mutation. In addition, the mutation is a named mutation: `AddStar`. It's up to you to give it any name. Last but not least, you can define the return values of the mutation by using objects and fields again. It's identical to a query. Finally, the variables tab provides the variable for the mutation you retrieved with the last query:
+
+这个变更操作的名称是由 GitHub API 起的： `addStar` 。你需要传递 `starrableId` 作为 `input` 来指定代码库；否则 GitHub 服务器无从得知这次变更操作是要 star 哪个代码库。另外，这个变更是一个具名变更为： `AddStar` 。你也可以给它任意名称。最后但也同样重要的是，你可以再次通过对象和字段来定义这个变更的返回值，这和查询是相同的。最终，在变量区中提供你在上一次查询得到的变量将被用于这一次变更操作：
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -462,7 +476,9 @@ The mutation's name is given by GitHub's API: `addStar`. You are required to pas
 }
 ~~~~~~~~
 
-Once you execute the mutation, the result should look like the following. Since you specified the return values of your mutation using the `id` and `viewerHasStarred` fields, you should see them in the result.
+> Once you execute the mutation, the result should look like the following. Since you specified the return values of your mutation using the `id` and `viewerHasStarred` fields, you should see them in the result.
+
+一旦你执行了这个变更操作，结果应该类似如下内容。因为你使用了 `id` 和 `viewerHasStarred` 字段指定你的变更的返回值，所以你应该能在结果中找到它们。
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -478,24 +494,53 @@ Once you execute the mutation, the result should look like the following. Since 
 }
 ~~~~~~~~
 
-The repository is starred now. It's visible in the result, but you can verify it in the [repository on GitHub](https://github.com/the-road-to-learn-react/the-road-to-learn-react). Congratulations, you made your first mutation.
+> The repository is starred now. It's visible in the result, but you can verify it in the [repository on GitHub](https://github.com/the-road-to-learn-react/the-road-to-learn-react). Congratulations, you made your first mutation.
 
-### Exercises:
+这个代码库现在已经被 star 了。在返回的结果中能够看到，但你也可以通过查看[ GitHub 上的代码库](https://github.com/the-road-to-learn-react/the-road-to-learn-react)来确认。恭喜，你完成了你的第一个变更操作。
 
-* Read more about [the Mutation in GraphQL](http://graphql.org/learn/queries/#mutations)
-* Explore GitHub's mutations by using the "Docs" sidebar in GraphiQL
-* Find GitHub's `addStar` mutation in the "Docs" sidebar in GraphiQL
-  * Check its possible fields for returning a response
-* Create a few other mutations for this or another repository such as:
-  * Unstar repository
-  * Watch repository
-* Create two named mutations side by side in the GraphiQL panel and execute them
-* Read more about [the schema and types](http://graphql.org/learn/schema)
-  * Make yourself a picture of it, but don't worry if you don't understand everything yet
+> ### Exercises:
 
-## GraphQL Pagination
+### 练习：
 
-This is where we return to the concept of **pagination** mentioned in the first chapter. Imagine you have a list of repositories in your GitHub organization, but you only want to retrieve a few of them to display in your UI. It could take ages to fetch a list of repositories from a large organization. In GraphQL, you can request paginated data by providing arguments to a **list field**, such as an argument that says how many items you are expecting from the list.
+> * Read more about [the Mutation in GraphQL](http://graphql.org/learn/queries/#mutations)
+
+* 阅读更多关于[ GraphQL 中的变更](http://graphql.org/learn/queries/#mutations)
+
+> * Explore GitHub's mutations by using the "Docs" sidebar in GraphiQL
+
+* 通过 GraphiQL 上的 "Docs" 侧边栏探索 GitHub 的更多变更操作
+
+> * Find GitHub's `addStar` mutation in the "Docs" sidebar in GraphiQL
+> 	* Check its possible fields for returning a response 	
+
+* 在 GraphiQL 上的 "Docs" 侧边栏中找到 GitHub 的 `addStar` 变更
+  * 检查它所有可以返回的字段
+
+> * Create a few other mutations for this or another repository such as:
+>   * Unstar repository
+>   * Watch repository
+
+* 对该代码库或另一个代码库构造一些其他变更操作，比如：
+	* 取消 Star 代码库
+	* Watch 代码库
+
+> * Create two named mutations side by side in the GraphiQL panel and execute them
+
+* 在 GraphiQL 面板上创建两个并列的命名变更，然后执行它们
+
+> * Read more about [the schema and types](http://graphql.org/learn/schema)
+>   * Make yourself a picture of it, but don't worry if you don't understand everything yet
+
+* 延伸阅读：[schema 和类型](http://graphql.org/learn/schema)
+	* 你可以只是大概了解一下，不要担心你有不理解的地方
+
+> ## GraphQL Pagination
+
+## GraphQL 分页
+
+> This is where we return to the concept of **pagination** mentioned in the first chapter. Imagine you have a list of repositories in your GitHub organization, but you only want to retrieve a few of them to display in your UI. It could take ages to fetch a list of repositories from a large organization. In GraphQL, you can request paginated data by providing arguments to a **list field**, such as an argument that says how many items you are expecting from the list.
+
+这里我们回到了在第一节提到的**分页**的概念。试想你在你的 GitHub 组织下有一个代码库列表，但你只想获得它们中的一部分来展示在你的 UI 上。如果是从一个大型组织下获取一个代码库列表的话，那将花费大量的时间。在 GraphQL 中，你可以通过提供参数到一个**列举字段**来请求分页数据，比如一个表明你希望从列表中获得多少项的参数。
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -516,9 +561,13 @@ query OrganizationForLearningReact {
 }
 ~~~~~~~~
 
-A `first` argument is passed to the `repositories` list field that specifies how many items from the list are expected in the result. The query shape doesn't need to follow the `edges` and `node` structure, but it's one of a few solutions to define paginated data structures and lists with GraphQL. Actually, it follows the interface description of Facebook's GraphQL client called Relay. GitHub followed this approach and adopted it for their own GraphQL pagination API. Later, you will learn in the exercises about other strategies to implement pagination with GraphQL.
+> A `first` argument is passed to the `repositories` list field that specifies how many items from the list are expected in the result. The query shape doesn't need to follow the `edges` and `node` structure, but it's one of a few solutions to define paginated data structures and lists with GraphQL. Actually, it follows the interface description of Facebook's GraphQL client called Relay. GitHub followed this approach and adopted it for their own GraphQL pagination API. Later, you will learn in the exercises about other strategies to implement pagination with GraphQL.
 
-After executing the query, you should see two items from the list in the repositories field. We still need to figure out how to fetch the next two repositories in the list, however. The first result of the query is the first **page** of the paginated list, the second query result should be the second page. In the following, you will see how the query structure for paginated data allows us to retrieve meta information to execute successive queries. For instance, each edge comes with its own cursor field to identify its position in the list.
+这里一个 `first` 参数被传给了 `repositories` 的列举字段来指定希望从列表中获得多少项作为结果。这个查询没有被要求按照 `edges` 和 `node` 的结构编写，不过这也是仅有的几种 GraphQL 定义分页数据结构和列表的方案之一。实际上它是借鉴了 Facebook GraphQL 客户端 Relay 的接口描述方案。GitHub 按照它的方式并采纳到了自己的 GraphQL 分页 API 中。之后你将会在练习中了解到其他用 GraphQL 实现分页的方法。
+
+> After executing the query, you should see two items from the list in the repositories field. We still need to figure out how to fetch the next two repositories in the list, however. The first result of the query is the first **page** of the paginated list, the second query result should be the second page. In the following, you will see how the query structure for paginated data allows us to retrieve meta information to execute successive queries. For instance, each edge comes with its own cursor field to identify its position in the list.
+
+在执行这个查询之后，你应该能在 repositories 字段的列表中看到两项。然而，我们仍然需要寻找如何拿到代码库列表中之后两项的办法。这个查询的第一次结果是分页列表的第一**页**，而第二次查询的结果应该是第二页。接下来，你会看到分页数据的查询结构是如何允许我们获得元信息来执行连续的查询。比如，每个 edge 有它自己的 游标字段来指明它在列表中的位置。
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -540,7 +589,9 @@ query OrganizationForLearningReact {
 }
 ~~~~~~~~
 
-The result should be similar to the following:
+> The result should be similar to the following:
+
+结果类似如下内容：
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -570,7 +621,9 @@ The result should be similar to the following:
 }
 ~~~~~~~~
 
-Now, you can use the cursor of the first repository in the list to execute a second query. By using the `after` argument for the `repositories` list field, you can specify an entry point to retrieve your next page of paginated data. What would the result look like when executing the following query?
+> Now, you can use the cursor of the first repository in the list to execute a second query. By using the `after` argument for the `repositories` list field, you can specify an entry point to retrieve your next page of paginated data. What would the result look like when executing the following query?
+
+现在你可以使用列表中第一个代码库的游标来执行第二个查询。通过给 `repositories` 的列举字段使用 `after` 参数，你可以指定获得下一页分页数据的起点。那么执行下面的查询后的结果会是什么样呢？
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -592,14 +645,25 @@ query OrganizationForLearningReact {
 }
 ~~~~~~~~
 
-In the previous result, only the second item is retrieved, as well as a new third item. The first item isn't retrieved because you have used its cursor as `after` argument to retrieve all items after it. Now you can imagine how to make successive queries for paginated lists:
+> In the previous result, only the second item is retrieved, as well as a new third item. The first item isn't retrieved because you have used its cursor as `after` argument to retrieve all items after it. Now you can imagine how to make successive queries for paginated lists:
 
-* Execute the initial query without a cursor argument
-* Execute every following query with the cursor of the **last** item's cursor from the previous query result
+在上一个结果中，只有第二项和一个新的第三项被取到了。第一项没有被取到因为你使用了它的游标作为 `after` 参数来取得它之后的所有元素。现在你可能已经想到如何来进行连续的分页列表查询了：
 
-To keep the query dynamic, we extract its arguments as variables. Afterward, you can use the query with a dynamic `cursor` argument by providing a variable for it. The `after` argument can be `undefined` to retrieve the first page. In conclusion, that would be everything you need to fetch pages of lists from one large list by using a feature called pagination. You need a mandatory argument specifying how many items should be retrieved and an optional argument, in this case the `after` argument, specifying the starting point for the list.
+> * Execute the initial query without a cursor argument
 
-There are also a couple helpful ways to use meta information for your paginated list. Retrieving the `cursor` field for every repository may be verbose when using only the `cursor` of the last repository, so you can remove the `cursor` field for an individual edge, but add the `pageInfo` object with its `endCursor` and `hasNextPage` fields. You can also request the `totalCount` of the list.
+* 不带游标参数执行初始查询
+
+> * Execute every following query with the cursor of the **last** item's cursor from the previous query result
+
+* 执行接下来的查询的时候，使用上一次查询结果中**最后**一项的游标作为该次查询的游标
+
+> To keep the query dynamic, we extract its arguments as variables. Afterward, you can use the query with a dynamic `cursor` argument by providing a variable for it. The `after` argument can be `undefined` to retrieve the first page. In conclusion, that would be everything you need to fetch pages of lists from one large list by using a feature called pagination. You need a mandatory argument specifying how many items should be retrieved and an optional argument, in this case the `after` argument, specifying the starting point for the list.
+
+为了保持查询是动态的，我们可以把它的参数都抽成变量。然后你可以通过提供变量来使用拥有动态的 `cursor` 参数的查询。为了获取第一页，`after` 参数可以是 `undefined` 。最后，这就是所有关于你如何使用一个被称为分页的功能来从一个巨大的列表中获取很多页列表。你需要一个必需的参数来指明应该取得多少项以及一个可选参数，在这个例子中是 `after` 参数，来指明列表的起始点。
+
+>  There are also a couple helpful ways to use meta information for your paginated list. Retrieving the `cursor` field for every repository may be verbose when using only the `cursor` of the last repository, so you can remove the `cursor` field for an individual edge, but add the `pageInfo` object with its `endCursor` and `hasNextPage` fields. You can also request the `totalCount` of the list.
+
+也有一些其他有用的方式通过使用元信息来为你的列表分页。当只使用最后一个代码库的 `cursor` 的时候，给每一个代码库都取得 `cursor` 字段可能显得很冗长，所以你可以给单独的 edge 去掉 `cursor` 字段，但给 `pageInfo` 对象加上它的 `endCursor` 和 `hasNextPage` 字段。你也可以请求列表的 `totalCount` 。
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -627,25 +691,52 @@ query OrganizationForLearningReact {
 }
 ~~~~~~~~
 
-The `totalCount` field discloses the total number of items in the list, while the `pageInfo` field gives you information about two things:
+> The `totalCount` field discloses the total number of items in the list, while the `pageInfo` field gives you information about two things:
 
-* **`endCursor`** can be used to retrieve the successive list, which we did with the `cursor` field, except this time we only need one meta field to perform it. The cursor of the last list item is sufficient to request the next page of list.
+这个 `totalCount` 字段表明了列表中元素的数量，而 `pageInfo` 字段给你提供了两个信息：
 
-* **`hasNextPage`** gives you information about whether or not there is a next page to retrieve from the GraphQL API. Sometimes you've already fetched the last page from your server. For applications that use infinite scrolling to load more pages when scrolling lists, you can stop fetching pages when there are no more available.
+> * **`endCursor`** can be used to retrieve the successive list, which we did with the `cursor` field, except this time we only need one meta field to perform it. The cursor of the last list item is sufficient to request the next page of list.
 
-This meta information completes the pagination implementation. Information is made accessible using the GraphQL API to implement [paginated lists](https://www.robinwieruch.de/react-paginated-list/) and [infinite scroll](https://www.robinwieruch.de/react-infinite-scroll/). Note, this covers GitHub's GraphQL API; a different GraphQL API for pagination might use different naming conventions for the fields, exclude meta information, or employ different mechanisms altogether.
+* 和我们使用 `cursor` 字段一样，**`endCursor`** 也可以用来获取连续的列表，除了这一次我们只需要一个元字段来实现。但列表最后一项的 cursor 是足够用来请求列表中下一页的。
 
-### Exercises:
+> * **`hasNextPage`** gives you information about whether or not there is a next page to retrieve from the GraphQL API. Sometimes you've already fetched the last page from your server. For applications that use infinite scrolling to load more pages when scrolling lists, you can stop fetching pages when there are no more available.
 
-* Extract the `login` and the `cursor` from your pagination query as variables.
-* Exchange the `first` argument with a `last` argument.
-* Search for the `repositories` field in the GraphiQL "Docs" sidebar which says: "A list of repositories that the ... owns."
-  * Explore the other arguments that can be passed to this list field.
-  * Use the `orderBy` argument to retrieve an ascending or descending list.
-* Read more about [pagination in GraphQL](http://graphql.org/learn/pagination).
-  * The cursor approach is only one solution which is used by GitHub.
-  * Make sure to understand the other solutions, too.
+* **`hasNextPage`** 告诉了你是否还能通过 GraphQL API 获得下一页。有时候你已经从你的服务端获得了最后一页。对于那些在滚动列表加载更多页的时候使用无限滚动的应用，你可以在没有下一页的情况下，停止获取页面信息。
+
+> This meta information completes the pagination implementation. Information is made accessible using the GraphQL API to implement [paginated lists](https://www.robinwieruch.de/react-paginated-list/) and [infinite scroll](https://www.robinwieruch.de/react-infinite-scroll/). Note, this covers GitHub's GraphQL API; a different GraphQL API for pagination might use different naming conventions for the fields, exclude meta information, or employ different mechanisms altogether.
+
+通过元信息可以完整地实现分页。使用 GraphQL API 来实现[分页列表](https://www.robinwieruch.de/react-paginated-list/)和[无限滚动](https://www.robinwieruch.de/react-infinite-scroll/)使得信息更加方便。注意这包含了 GitHub 的 GraphQL API; 一个不同的分页的 GraphQL API 的字段可能使用了不同的命名方式，除了元信息或者采用完全不同的机制。
+
+> ### Exercises:
+
+### 练习：
+
+> * Extract the `login` and the `cursor` from your pagination query as variables.
+
+* 把你的分页查询中的 `login` 和 `cursor` 抽为变量。
+
+> * Exchange the `first` argument with a `last` argument.
+
+* 把`first` 参数替换为 `last` 参数。
+
+> * Search for the `repositories` field in the GraphiQL "Docs" sidebar which says: "A list of repositories that the ... owns."
+>   * Explore the other arguments that can be passed to this list field.
+>   * Use the `orderBy` argument to retrieve an ascending or descending list.
+
+* 在 GraphiQL 的 "Docs" 侧边栏搜索 `repositories` 字段会看到："A list of repositories that the ... owns."
+	* 探索其他可以传给这个列举字段的参数。
+	* 使用 `orderBy` 参数来获取一个递增或者递减的列表。
+
+> * Read more about [pagination in GraphQL](http://graphql.org/learn/pagination).
+>   * The cursor approach is only one solution which is used by GitHub.
+>   * Make sure to understand the other solutions, too.
+
+* 延伸阅读：[GraphQL 中的分页](http://graphql.org/learn/pagination)。
+  * 使用游标是 GitHub 唯一使用的解决方案。
+  * 请确保同样理解其他的解决方案。
 
 | |
 
-Interacting with GitHub's GraphQL API via GraphiQL or GitHub's GraphQL Explorer is only the beginning. You should be familiar with the fundamental GraphQL concepts now. But there are a lot more exciting concepts to explore. In the next chapters, you will implement a fully working GraphQL client application with React that interacts with GitHub's API.
+> Interacting with GitHub's GraphQL API via GraphiQL or GitHub's GraphQL Explorer is only the beginning. You should be familiar with the fundamental GraphQL concepts now. But there are a lot more exciting concepts to explore. In the next chapters, you will implement a fully working GraphQL client application with React that interacts with GitHub's API.
+
+通过 GraphiQL 或者 GitHub 提供的 GraphQL Explorer 来与 GitHub 的 GraphQL API 交互仅仅只是开始。你现在应该已经掌握了 GraphQL 的基本概念。但是仍然有很多更加有趣的概念可以探索。在接下来的章节中，你将会实现一个完整运行的使用 React 与 GitHub 的 API 进行交互的 GraphQL 客户端应用。

--- a/manuscript/04-graphql-fundamentals/index.md
+++ b/manuscript/04-graphql-fundamentals/index.md
@@ -320,21 +320,13 @@ The query in GraphQL gives you all you need to read data from a GraphQL API. The
   * operation names
   * directives
 
-> ## GraphQL Operation: Mutation
+## GraphQL Operation: Mutation
 
-## GraphQL 基础：变更
+This section introduces the GraphQL mutation. It complements the GraphQL query because it is used for writing data instead of reading it. The mutation shares the same principles as the query: it has fields and objects, arguments and variables, fragments and operation names, as well as directives and nested objects for the returned result. With mutations you can specify data as fields and objects that should be returned after it 'mutates' into something acceptable. Before you start making your first mutation, be aware that you are using live GitHub data, so if you follow a person on GitHub using your experimental mutation, you will follow this person for real. Fortunately this sort of behavior is encouraged on GitHub.
 
-> This section introduces the GraphQL mutation. It complements the GraphQL query because it is used for writing data instead of reading it. The mutation shares the same principles as the query: it has fields and objects, arguments and variables, fragments and operation names, as well as directives and nested objects for the returned result. With mutations you can specify data as fields and objects that should be returned after it 'mutates' into something acceptable. Before you start making your first mutation, be aware that you are using live GitHub data, so if you follow a person on GitHub using your experimental mutation, you will follow this person for real. Fortunately this sort of behavior is encouraged on GitHub.
+In this section, you will star a repository on GitHub, the same one you used a query to request before, using a mutation [from GitHub's API](https://developer.github.com/v4/mutation/addstar). You can find the `addStar` mutation in the "Docs" sidebar. The repository is a project for teaching developers about the fundamentals of React, so starring it should prove useful.
 
-这部分将会介绍 GraphQL 变更操作。它作为 GraphQL 查询的补充，用于改写数据而不是读取。变更操作和查询操作拥有着同样的规则：拥有字段和对象、参数和变量、片段和操作名称、指令和返回结果中的嵌套对象。通过变更操作你可以指定在"更新"发生后所期望的返回数据的字段和对象。在你开始你的第一次变更操作之前，请注意你在使用真实的 GitHub 数据，也就是说如果你在尝试变更操作的时候关注了 GitHub 上的一个人，你就真的关注了这个人。幸运的是这种行为在 GitHub 上是受到鼓励的。
-
-> In this section, you will star a repository on GitHub, the same one you used a query to request before, using a mutation [from GitHub's API](https://developer.github.com/v4/mutation/addstar). You can find the `addStar` mutation in the "Docs" sidebar. The repository is a project for teaching developers about the fundamentals of React, so starring it should prove useful.
-
-接下来你将会 star 一个 GitHub 上的代码库，而和你之前使用一个查询来请求一样，你将使用[来自 GitHub API ](https://developer.github.com/v4/mutation/addstar)的一个变更请求。你可以在 "Docs" 侧边栏中找到 `addStar` 这种变更操作。这是一个存放为开发者讲解 React 基础课程的代码库，所以 star 这个代码库能够证明它有用。
-
-> You can visit [the repository](https://github.com/the-road-to-learn-react/the-road-to-learn-react) to see if you've given a star to the repository already. We want an unstarred repository so we can star it using a mutation. Before you can star a repository, you need to know its identifier, which can be retrieved by a query:
-
-你可以访问[这个代码库](https://github.com/the-road-to-learn-react/the-road-to-learn-react)来查看你是否已经成功 star 。我们想要一个尚未 star 过的代码库，这样我们可以通过一个变更操作来 star 它。在你 star 一个代码库前，你需要知道它的唯一标识。这个唯一标识你可以通过下面的查询获取：
+You can visit [the repository](https://github.com/the-road-to-learn-react/the-road-to-learn-react) to see if you've given a star to the repository already. We want an unstarred repository so we can star it using a mutation. Before you can star a repository, you need to know its identifier, which can be retrieved by a query:
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -352,18 +344,14 @@ query {
 }
 ~~~~~~~~
 
-> In the results for the query in GraphiQL, you should see the identifier for the repository:
-
-在 GraphiQL 的该查询结果中，你应该能看到代码库的唯一标识：
+In the results for the query in GraphiQL, you should see the identifier for the repository:
 
 {title="Code Playground",lang="json"}
 ~~~~~~~~
 MDEwOlJlcG9zaXRvcnk2MzM1MjkwNw==
 ~~~~~~~~
 
->  Before using the identifier as a variable, you can structure your mutation in GraphiQL the following way:
-
-在使用唯一标示作为变量之前，你可以在 GraphiQL 中使用以下结构的变更操作：
+Before using the identifier as a variable, you can structure your mutation in GraphiQL the following way:
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -377,9 +365,7 @@ mutation AddStar($repositoryId: ID!) {
 }
 ~~~~~~~~
 
-> The mutation's name is given by GitHub's API: `addStar`. You are required to pass it the `starrableId` as `input` to identify the repository; otherwise, the GitHub server won't know which repository to star with the mutation. In addition, the mutation is a named mutation: `AddStar`. It's up to you to give it any name. Last but not least, you can define the return values of the mutation by using objects and fields again. It's identical to a query. Finally, the variables tab provides the variable for the mutation you retrieved with the last query:
-
-这个变更操作的名称是由 GitHub API 起的： `addStar` 。你需要传递 `starrableId` 作为 `input` 来指定代码库；否则 GitHub 服务器无从得知这次变更操作是要 star 哪个代码库。另外，这个变更是一个具名变更为： `AddStar` 。你也可以给它任意名称。最后但也同样重要的是，你可以再次通过对象和字段来定义这个变更的返回值，这和查询是相同的。最终，在变量区中提供你在上一次查询得到的变量将被用于这一次变更操作：
+The mutation's name is given by GitHub's API: `addStar`. You are required to pass it the `starrableId` as `input` to identify the repository; otherwise, the GitHub server won't know which repository to star with the mutation. In addition, the mutation is a named mutation: `AddStar`. It's up to you to give it any name. Last but not least, you can define the return values of the mutation by using objects and fields again. It's identical to a query. Finally, the variables tab provides the variable for the mutation you retrieved with the last query:
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -388,9 +374,7 @@ mutation AddStar($repositoryId: ID!) {
 }
 ~~~~~~~~
 
-> Once you execute the mutation, the result should look like the following. Since you specified the return values of your mutation using the `id` and `viewerHasStarred` fields, you should see them in the result.
-
-一旦你执行了这个变更操作，结果应该类似如下内容。因为你使用了 `id` 和 `viewerHasStarred` 字段指定你的变更的返回值，所以你应该能在结果中找到它们。
+Once you execute the mutation, the result should look like the following. Since you specified the return values of your mutation using the `id` and `viewerHasStarred` fields, you should see them in the result.
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -406,53 +390,24 @@ mutation AddStar($repositoryId: ID!) {
 }
 ~~~~~~~~
 
-> The repository is starred now. It's visible in the result, but you can verify it in the [repository on GitHub](https://github.com/the-road-to-learn-react/the-road-to-learn-react). Congratulations, you made your first mutation.
+The repository is starred now. It's visible in the result, but you can verify it in the [repository on GitHub](https://github.com/the-road-to-learn-react/the-road-to-learn-react). Congratulations, you made your first mutation.
 
-这个代码库现在已经被 star 了。在返回的结果中能够看到，但你也可以通过查看[ GitHub 上的代码库](https://github.com/the-road-to-learn-react/the-road-to-learn-react)来确认。恭喜，你完成了你的第一个变更操作。
+### Exercises:
 
-> ### Exercises:
+* Read more about [the Mutation in GraphQL](http://graphql.org/learn/queries/#mutations)
+* Explore GitHub's mutations by using the "Docs" sidebar in GraphiQL
+* Find GitHub's `addStar` mutation in the "Docs" sidebar in GraphiQL
+  * Check its possible fields for returning a response
+* Create a few other mutations for this or another repository such as:
+  * Unstar repository
+  * Watch repository
+* Create two named mutations side by side in the GraphiQL panel and execute them
+* Read more about [the schema and types](http://graphql.org/learn/schema)
+  * Make yourself a picture of it, but don't worry if you don't understand everything yet
 
-### 练习：
+## GraphQL Pagination
 
-> * Read more about [the Mutation in GraphQL](http://graphql.org/learn/queries/#mutations)
-
-* 阅读更多关于[ GraphQL 中的变更](http://graphql.org/learn/queries/#mutations)
-
-> * Explore GitHub's mutations by using the "Docs" sidebar in GraphiQL
-
-* 通过 GraphiQL 上的 "Docs" 侧边栏探索 GitHub 的更多变更操作
-
-> * Find GitHub's `addStar` mutation in the "Docs" sidebar in GraphiQL
-> 	* Check its possible fields for returning a response 	
-
-* 在 GraphiQL 上的 "Docs" 侧边栏中找到 GitHub 的 `addStar` 变更
-  * 检查它所有可以返回的字段
-
-> * Create a few other mutations for this or another repository such as:
->   * Unstar repository
->   * Watch repository
-
-* 对该代码库或另一个代码库构造一些其他变更操作，比如：
-	* 取消 Star 代码库
-	* Watch 代码库
-
-> * Create two named mutations side by side in the GraphiQL panel and execute them
-
-* 在 GraphiQL 面板上创建两个并列的命名变更，然后执行它们
-
-> * Read more about [the schema and types](http://graphql.org/learn/schema)
->   * Make yourself a picture of it, but don't worry if you don't understand everything yet
-
-* 延伸阅读：[schema 和类型](http://graphql.org/learn/schema)
-	* 你可以只是大概了解一下，不要担心你有不理解的地方
-
-> ## GraphQL Pagination
-
-## GraphQL 分页
-
-> This is where we return to the concept of **pagination** mentioned in the first chapter. Imagine you have a list of repositories in your GitHub organization, but you only want to retrieve a few of them to display in your UI. It could take ages to fetch a list of repositories from a large organization. In GraphQL, you can request paginated data by providing arguments to a **list field**, such as an argument that says how many items you are expecting from the list.
-
-这里我们回到了在第一节提到的**分页**的概念。试想你在你的 GitHub 组织下有一个代码库列表，但你只想获得它们中的一部分来展示在你的 UI 上。如果是从一个大型组织下获取一个代码库列表的话，那将花费大量的时间。在 GraphQL 中，你可以通过提供参数到一个**列举字段**来请求分页数据，比如一个表明你希望从列表中获得多少项的参数。
+This is where we return to the concept of **pagination** mentioned in the first chapter. Imagine you have a list of repositories in your GitHub organization, but you only want to retrieve a few of them to display in your UI. It could take ages to fetch a list of repositories from a large organization. In GraphQL, you can request paginated data by providing arguments to a **list field**, such as an argument that says how many items you are expecting from the list.
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -473,13 +428,9 @@ query OrganizationForLearningReact {
 }
 ~~~~~~~~
 
-> A `first` argument is passed to the `repositories` list field that specifies how many items from the list are expected in the result. The query shape doesn't need to follow the `edges` and `node` structure, but it's one of a few solutions to define paginated data structures and lists with GraphQL. Actually, it follows the interface description of Facebook's GraphQL client called Relay. GitHub followed this approach and adopted it for their own GraphQL pagination API. Later, you will learn in the exercises about other strategies to implement pagination with GraphQL.
+A `first` argument is passed to the `repositories` list field that specifies how many items from the list are expected in the result. The query shape doesn't need to follow the `edges` and `node` structure, but it's one of a few solutions to define paginated data structures and lists with GraphQL. Actually, it follows the interface description of Facebook's GraphQL client called Relay. GitHub followed this approach and adopted it for their own GraphQL pagination API. Later, you will learn in the exercises about other strategies to implement pagination with GraphQL.
 
-这里一个 `first` 参数被传给了 `repositories` 的列举字段来指定希望从列表中获得多少项作为结果。这个查询没有被要求按照 `edges` 和 `node` 的结构编写，不过这也是仅有的几种 GraphQL 定义分页数据结构和列表的方案之一。实际上它是借鉴了 Facebook GraphQL 客户端 Relay 的接口描述方案。GitHub 按照它的方式并采纳到了自己的 GraphQL 分页 API 中。之后你将会在练习中了解到其他用 GraphQL 实现分页的方法。
-
-> After executing the query, you should see two items from the list in the repositories field. We still need to figure out how to fetch the next two repositories in the list, however. The first result of the query is the first **page** of the paginated list, the second query result should be the second page. In the following, you will see how the query structure for paginated data allows us to retrieve meta information to execute successive queries. For instance, each edge comes with its own cursor field to identify its position in the list.
-
-在执行这个查询之后，你应该能在 repositories 字段的列表中看到两项。然而，我们仍然需要寻找如何拿到代码库列表中之后两项的办法。这个查询的第一次结果是分页列表的第一**页**，而第二次查询的结果应该是第二页。接下来，你会看到分页数据的查询结构是如何允许我们获得元信息来执行连续的查询。比如，每个 edge 有它自己的 游标字段来指明它在列表中的位置。
+After executing the query, you should see two items from the list in the repositories field. We still need to figure out how to fetch the next two repositories in the list, however. The first result of the query is the first **page** of the paginated list, the second query result should be the second page. In the following, you will see how the query structure for paginated data allows us to retrieve meta information to execute successive queries. For instance, each edge comes with its own cursor field to identify its position in the list.
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -501,9 +452,7 @@ query OrganizationForLearningReact {
 }
 ~~~~~~~~
 
-> The result should be similar to the following:
-
-结果类似如下内容：
+The result should be similar to the following:
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -533,9 +482,7 @@ query OrganizationForLearningReact {
 }
 ~~~~~~~~
 
-> Now, you can use the cursor of the first repository in the list to execute a second query. By using the `after` argument for the `repositories` list field, you can specify an entry point to retrieve your next page of paginated data. What would the result look like when executing the following query?
-
-现在你可以使用列表中第一个代码库的游标来执行第二个查询。通过给 `repositories` 的列举字段使用 `after` 参数，你可以指定获得下一页分页数据的起点。那么执行下面的查询后的结果会是什么样呢？
+Now, you can use the cursor of the first repository in the list to execute a second query. By using the `after` argument for the `repositories` list field, you can specify an entry point to retrieve your next page of paginated data. What would the result look like when executing the following query?
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -557,25 +504,14 @@ query OrganizationForLearningReact {
 }
 ~~~~~~~~
 
-> In the previous result, only the second item is retrieved, as well as a new third item. The first item isn't retrieved because you have used its cursor as `after` argument to retrieve all items after it. Now you can imagine how to make successive queries for paginated lists:
+In the previous result, only the second item is retrieved, as well as a new third item. The first item isn't retrieved because you have used its cursor as `after` argument to retrieve all items after it. Now you can imagine how to make successive queries for paginated lists:
 
-在上一个结果中，只有第二项和一个新的第三项被取到了。第一项没有被取到因为你使用了它的游标作为 `after` 参数来取得它之后的所有元素。现在你可能已经想到如何来进行连续的分页列表查询了：
+* Execute the initial query without a cursor argument
+* Execute every following query with the cursor of the **last** item's cursor from the previous query result
 
-> * Execute the initial query without a cursor argument
+To keep the query dynamic, we extract its arguments as variables. Afterward, you can use the query with a dynamic `cursor` argument by providing a variable for it. The `after` argument can be `undefined` to retrieve the first page. In conclusion, that would be everything you need to fetch pages of lists from one large list by using a feature called pagination. You need a mandatory argument specifying how many items should be retrieved and an optional argument, in this case the `after` argument, specifying the starting point for the list.
 
-* 不带游标参数执行初始查询
-
-> * Execute every following query with the cursor of the **last** item's cursor from the previous query result
-
-* 执行接下来的查询的时候，使用上一次查询结果中**最后**一项的游标作为该次查询的游标
-
-> To keep the query dynamic, we extract its arguments as variables. Afterward, you can use the query with a dynamic `cursor` argument by providing a variable for it. The `after` argument can be `undefined` to retrieve the first page. In conclusion, that would be everything you need to fetch pages of lists from one large list by using a feature called pagination. You need a mandatory argument specifying how many items should be retrieved and an optional argument, in this case the `after` argument, specifying the starting point for the list.
-
-为了保持查询是动态的，我们可以把它的参数都抽成变量。然后你可以通过提供变量来使用拥有动态的 `cursor` 参数的查询。为了获取第一页，`after` 参数可以是 `undefined` 。最后，这就是所有关于你如何使用一个被称为分页的功能来从一个巨大的列表中获取很多页列表。你需要一个必需的参数来指明应该取得多少项以及一个可选参数，在这个例子中是 `after` 参数，来指明列表的起始点。
-
->  There are also a couple helpful ways to use meta information for your paginated list. Retrieving the `cursor` field for every repository may be verbose when using only the `cursor` of the last repository, so you can remove the `cursor` field for an individual edge, but add the `pageInfo` object with its `endCursor` and `hasNextPage` fields. You can also request the `totalCount` of the list.
-
-也有一些其他有用的方式通过使用元信息来为你的列表分页。当只使用最后一个代码库的 `cursor` 的时候，给每一个代码库都取得 `cursor` 字段可能显得很冗长，所以你可以给单独的 edge 去掉 `cursor` 字段，但给 `pageInfo` 对象加上它的 `endCursor` 和 `hasNextPage` 字段。你也可以请求列表的 `totalCount` 。
+There are also a couple helpful ways to use meta information for your paginated list. Retrieving the `cursor` field for every repository may be verbose when using only the `cursor` of the last repository, so you can remove the `cursor` field for an individual edge, but add the `pageInfo` object with its `endCursor` and `hasNextPage` fields. You can also request the `totalCount` of the list.
 
 {title="GitHub GraphQL Explorer",lang="json"}
 ~~~~~~~~
@@ -603,52 +539,25 @@ query OrganizationForLearningReact {
 }
 ~~~~~~~~
 
-> The `totalCount` field discloses the total number of items in the list, while the `pageInfo` field gives you information about two things:
+The `totalCount` field discloses the total number of items in the list, while the `pageInfo` field gives you information about two things:
 
-这个 `totalCount` 字段表明了列表中元素的数量，而 `pageInfo` 字段给你提供了两个信息：
+* **`endCursor`** can be used to retrieve the successive list, which we did with the `cursor` field, except this time we only need one meta field to perform it. The cursor of the last list item is sufficient to request the next page of list.
 
-> * **`endCursor`** can be used to retrieve the successive list, which we did with the `cursor` field, except this time we only need one meta field to perform it. The cursor of the last list item is sufficient to request the next page of list.
+* **`hasNextPage`** gives you information about whether or not there is a next page to retrieve from the GraphQL API. Sometimes you've already fetched the last page from your server. For applications that use infinite scrolling to load more pages when scrolling lists, you can stop fetching pages when there are no more available.
 
-* 和我们使用 `cursor` 字段一样，**`endCursor`** 也可以用来获取连续的列表，除了这一次我们只需要一个元字段来实现。但列表最后一项的 cursor 是足够用来请求列表中下一页的。
+This meta information completes the pagination implementation. Information is made accessible using the GraphQL API to implement [paginated lists](https://www.robinwieruch.de/react-paginated-list/) and [infinite scroll](https://www.robinwieruch.de/react-infinite-scroll/). Note, this covers GitHub's GraphQL API; a different GraphQL API for pagination might use different naming conventions for the fields, exclude meta information, or employ different mechanisms altogether.
 
-> * **`hasNextPage`** gives you information about whether or not there is a next page to retrieve from the GraphQL API. Sometimes you've already fetched the last page from your server. For applications that use infinite scrolling to load more pages when scrolling lists, you can stop fetching pages when there are no more available.
+### Exercises:
 
-* **`hasNextPage`** 告诉了你是否还能通过 GraphQL API 获得下一页。有时候你已经从你的服务端获得了最后一页。对于那些在滚动列表加载更多页的时候使用无限滚动的应用，你可以在没有下一页的情况下，停止获取页面信息。
-
-> This meta information completes the pagination implementation. Information is made accessible using the GraphQL API to implement [paginated lists](https://www.robinwieruch.de/react-paginated-list/) and [infinite scroll](https://www.robinwieruch.de/react-infinite-scroll/). Note, this covers GitHub's GraphQL API; a different GraphQL API for pagination might use different naming conventions for the fields, exclude meta information, or employ different mechanisms altogether.
-
-通过元信息可以完整地实现分页。使用 GraphQL API 来实现[分页列表](https://www.robinwieruch.de/react-paginated-list/)和[无限滚动](https://www.robinwieruch.de/react-infinite-scroll/)使得信息更加方便。注意这包含了 GitHub 的 GraphQL API; 一个不同的分页的 GraphQL API 的字段可能使用了不同的命名方式，除了元信息或者采用完全不同的机制。
-
-> ### Exercises:
-
-### 练习：
-
-> * Extract the `login` and the `cursor` from your pagination query as variables.
-
-* 把你的分页查询中的 `login` 和 `cursor` 抽为变量。
-
-> * Exchange the `first` argument with a `last` argument.
-
-* 把`first` 参数替换为 `last` 参数。
-
-> * Search for the `repositories` field in the GraphiQL "Docs" sidebar which says: "A list of repositories that the ... owns."
->   * Explore the other arguments that can be passed to this list field.
->   * Use the `orderBy` argument to retrieve an ascending or descending list.
-
-* 在 GraphiQL 的 "Docs" 侧边栏搜索 `repositories` 字段会看到："A list of repositories that the ... owns."
-	* 探索其他可以传给这个列举字段的参数。
-	* 使用 `orderBy` 参数来获取一个递增或者递减的列表。
-
-> * Read more about [pagination in GraphQL](http://graphql.org/learn/pagination).
->   * The cursor approach is only one solution which is used by GitHub.
->   * Make sure to understand the other solutions, too.
-
-* 延伸阅读：[GraphQL 中的分页](http://graphql.org/learn/pagination)。
-  * 使用游标是 GitHub 唯一使用的解决方案。
-  * 请确保同样理解其他的解决方案。
+* Extract the `login` and the `cursor` from your pagination query as variables.
+* Exchange the `first` argument with a `last` argument.
+* Search for the `repositories` field in the GraphiQL "Docs" sidebar which says: "A list of repositories that the ... owns."
+  * Explore the other arguments that can be passed to this list field.
+  * Use the `orderBy` argument to retrieve an ascending or descending list.
+* Read more about [pagination in GraphQL](http://graphql.org/learn/pagination).
+  * The cursor approach is only one solution which is used by GitHub.
+  * Make sure to understand the other solutions, too.
 
 | |
 
-> Interacting with GitHub's GraphQL API via GraphiQL or GitHub's GraphQL Explorer is only the beginning. You should be familiar with the fundamental GraphQL concepts now. But there are a lot more exciting concepts to explore. In the next chapters, you will implement a fully working GraphQL client application with React that interacts with GitHub's API.
-
-通过 GraphiQL 或者 GitHub 提供的 GraphQL Explorer 来与 GitHub 的 GraphQL API 交互仅仅只是开始。你现在应该已经掌握了 GraphQL 的基本概念。但是仍然有很多更加有趣的概念可以探索。在接下来的章节中，你将会实现一个完整运行的使用 React 与 GitHub 的 API 进行交互的 GraphQL 客户端应用。
+Interacting with GitHub's GraphQL API via GraphiQL or GitHub's GraphQL Explorer is only the beginning. You should be familiar with the fundamental GraphQL concepts now. But there are a lot more exciting concepts to explore. In the next chapters, you will implement a fully working GraphQL client application with React that interacts with GitHub's API.


### PR DESCRIPTION
之前第四章后半部分的翻译错放在了index.md里，现在挪到了正确的index-cn.md里并且还原了英文index.md